### PR TITLE
Recognize clause heads not starting at the beginning of a line

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,23 +7,42 @@
 // ${cwd}: the current working directory of the spawned process
 // A task runner that calls a custom npm script that compiles the extension.
 {
-    "version": "0.1.0",
-    "isShellCommand": true,
+    "version": "2.0.0",
     "command": "npm",
     "args": [
         "run"
     ],
     "isBackground": true,
-    "showOutput": "always",
-    "tasks": [{
-            "taskName": "compile",
+    "tasks": [
+        {
+            "label": "compile",
+            "type": "shell",
+            "command": "npm",
+            "args": [
+                "run",
+                "compile"
+            ],
             "problemMatcher": "$tsc-watch"
         },
         {
-            "taskName": "syntax"
+            "label": "syntax",
+            "type": "shell",
+            "command": "npm",
+            "args": [
+                "run",
+                "syntax"
+            ],
+            "problemMatcher": []
         },
         {
-            "taskName": "updateVSCProlog"
+            "label": "updateVSCProlog",
+            "type": "shell",
+            "command": "npm",
+            "args": [
+                "run",
+                "updateVSCProlog"
+            ],
+            "problemMatcher": []
         }
     ]
 }

--- a/syntaxes/prolog.ecl.tmLanguage.json
+++ b/syntaxes/prolog.ecl.tmLanguage.json
@@ -47,7 +47,7 @@
     },
     {
       "name": "meta.clause.head.prolog",
-      "begin": "^\\s*([a-z][a-zA-Z0-9_]*)(\\(?)(?=.*:-.*)",
+      "begin": "\\s*([a-z][a-zA-Z0-9_]*)(\\(?)(?=.*:-.*)",
       "beginCaptures": {
         "1": {
           "name": "entity.name.function.clause.prolog"

--- a/syntaxes/prolog.ecl.tmLanguage.yaml
+++ b/syntaxes/prolog.ecl.tmLanguage.yaml
@@ -33,7 +33,7 @@ patterns:
         match: .
   -
     name: meta.clause.head.prolog
-    begin: '^\s*([a-z][a-zA-Z0-9_]*)(\(?)(?=.*:-.*)'
+    begin: '\s*([a-z][a-zA-Z0-9_]*)(\(?)(?=.*:-.*)'
     beginCaptures:
       '1':
         name: entity.name.function.clause.prolog

--- a/syntaxes/prolog.swi.tmLanguage.json
+++ b/syntaxes/prolog.swi.tmLanguage.json
@@ -47,7 +47,7 @@
     },
     {
       "name": "meta.clause.head.prolog",
-      "begin": "^\\s*([a-z][a-zA-Z0-9_]*)(\\(?)(?=.*:-.*)",
+      "begin": "\\s*([a-z][a-zA-Z0-9_]*)(\\(?)(?=.*:-.*)",
       "beginCaptures": {
         "1": {
           "name": "entity.name.function.clause.prolog"

--- a/syntaxes/prolog.swi.tmLanguage.yaml
+++ b/syntaxes/prolog.swi.tmLanguage.yaml
@@ -54,7 +54,7 @@ patterns:
         include: '#constants'
   -
     name: meta.dcg.head.prolog
-    begin: '^\s*([a-z][a-zA-Z0-9_]*)(\(?)(?=.*-->.*)'
+    begin: '\s*([a-z][a-zA-Z0-9_]*)(\(?)(?=.*-->.*)'
     beginCaptures:
       '1':
         name: entity.name.function.dcg.prolog


### PR DESCRIPTION
This had been bugging me for a while.
When multiple clauses are written on the same line, e.g.:

    father(mary, sam). father(june, sam).

The syntax highlight was only recognising the first clause. The
second one had to be placed on the next line.

This change allows clauses on the same line to be highlighted correctly.

Notes:
1. VScode automatically upgrades `tasks.json` to v2 format.
2. The `syntaxes/prolog.tmLanguage.json` file is a symlink to a private file in your home directory (` prolog.tmLanguage.json -> /Users/laowang/.vscode/extensions/vsc-prolog/syntaxes/prolog.swi.tmLanguage.json`).
3. The yml and json versions seem to be copies of each other just in a different format. Which one is canonical and which one is autogenerated? I changed them both manually.
4. I could not quickly understand the difference between the bare syntax file, the swi version and the ecl version. So I changed the swi and ecl versions by hand.

Before:
<img width="304" alt="CleanShot 2021-05-15 at 11 32 03@2x" src="https://user-images.githubusercontent.com/234072/118355614-2fa1d900-b571-11eb-8991-057dddd2669a.png">

After:
<img width="336" alt="CleanShot 2021-05-15 at 11 33 17@2x" src="https://user-images.githubusercontent.com/234072/118355650-5cee8700-b571-11eb-97bd-80a0e10649ac.png">

