### PR TITLE
Add syntax for back-quoted strings in SWI-Prolog

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,23 +7,42 @@
 // ${cwd}: the current working directory of the spawned process
 // A task runner that calls a custom npm script that compiles the extension.
 {
-    "version": "0.1.0",
-    "isShellCommand": true,
+    "version": "2.0.0",
     "command": "npm",
     "args": [
         "run"
     ],
     "isBackground": true,
-    "showOutput": "always",
-    "tasks": [{
-            "taskName": "compile",
+    "tasks": [
+        {
+            "label": "compile",
+            "type": "shell",
+            "command": "npm",
+            "args": [
+                "run",
+                "compile"
+            ],
             "problemMatcher": "$tsc-watch"
         },
         {
-            "taskName": "syntax"
+            "label": "syntax",
+            "type": "shell",
+            "command": "npm",
+            "args": [
+                "run",
+                "syntax"
+            ],
+            "problemMatcher": []
         },
         {
-            "taskName": "updateVSCProlog"
+            "label": "updateVSCProlog",
+            "type": "shell",
+            "command": "npm",
+            "args": [
+                "run",
+                "updateVSCProlog"
+            ],
+            "problemMatcher": []
         }
     ]
 }

--- a/snippets/prolog.json
+++ b/snippets/prolog.json
@@ -1,1 +1,1 @@
-/Users/laowang/.vscode/extensions/vsc-prolog/snippets/prolog.swi.json
+./prolog.swi.json

--- a/syntaxes/prolog.swi.tmLanguage.json
+++ b/syntaxes/prolog.swi.tmLanguage.json
@@ -232,6 +232,10 @@
         {
           "name": "string.quoted.double.prolog",
           "match": "\".*?\""
+        },
+        {
+          "name": "string.quoted.back.prolog",
+          "match": "`.*?`"
         }
       ]
     },

--- a/syntaxes/prolog.swi.tmLanguage.yaml
+++ b/syntaxes/prolog.swi.tmLanguage.yaml
@@ -155,6 +155,9 @@ repository:
       -
         name: string.quoted.double.prolog
         match: '".*?"'
+      -
+        name: string.quoted.back.prolog
+        match: "`.*?`"
   controlandkeywords:
     patterns:
       -

--- a/syntaxes/prolog.tmLanguage.json
+++ b/syntaxes/prolog.tmLanguage.json
@@ -1,1 +1,1 @@
-/Users/laowang/.vscode/extensions/vsc-prolog/syntaxes/prolog.swi.tmLanguage.json
+./prolog.swi.tmLanguage.json


### PR DESCRIPTION
- Enabled syntax highlighting for back-quoted strings in SWI-Prolog. Could probably add this for ECLiPSe as well, but I'm unfamiliar with that environment
- replaced absolute symlinks with relative paths to allow development on other peoples' machines